### PR TITLE
Tests for MessageForwardHandler and SessionExpireHandler

### DIFF
--- a/Server/src/test/java/octoteam/tahiti/server/pipeline/MessageForwardHandlerTest.java
+++ b/Server/src/test/java/octoteam/tahiti/server/pipeline/MessageForwardHandlerTest.java
@@ -1,0 +1,60 @@
+package octoteam.tahiti.server.pipeline;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import octoteam.tahiti.protocol.SocketMessageProtos.ChatMessageReqBody;
+import octoteam.tahiti.protocol.SocketMessageProtos.Message;
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MessageForwardHandlerTest {
+
+    @Test
+    public void testMessageForward() {
+
+        // MessageForwardHandler should construct CHAT_BROADCAST_EVENT message only when received CHAT_SEND_MESSAGE_REQUEST message
+
+        EmbeddedChannel channel = new EmbeddedChannel(new MessageForwardHandler());
+
+        Message msgRequest = Message.newBuilder()
+                .setSeqId(1038)
+                .setDirection(Message.DirectionCode.REQUEST)
+                .setService(Message.ServiceCode.CHAT_SEND_MESSAGE_REQUEST)
+                .setChatMessageReq(ChatMessageReqBody.newBuilder()
+                        .setPayload("HELLO :P")
+                        .setTimestamp(Calendar.getInstance().getTimeInMillis())
+                ).build();
+
+        channel.writeInbound(msgRequest);
+        channel.finish();
+
+        // message is handled so inbound got nothing
+        assertNull(channel.readInbound());
+        // not writing CHAT_BROADCAST_EVENT message to itself
+        assertNull(channel.readOutbound());
+    }
+
+    @Test
+    public void testOtherRequest() {
+
+        EmbeddedChannel channel = new EmbeddedChannel(new MessageForwardHandler());
+
+        Message msgRequest = Message.newBuilder()
+                .setSeqId(1038)
+                .setDirection(Message.DirectionCode.REQUEST)
+                .setService(Message.ServiceCode.PING_REQUEST)
+                .setChatMessageReq(ChatMessageReqBody.newBuilder()
+                        .setPayload("HELLO :P")
+                        .setTimestamp(Calendar.getInstance().getTimeInMillis())
+                ).build();
+
+        channel.writeInbound(msgRequest);
+        channel.finish();
+
+        // message is not handled so passed to next handler and show up in inbound
+        assertEquals(msgRequest, channel.readInbound());
+    }
+}

--- a/Server/src/test/java/octoteam/tahiti/server/pipeline/SessionExpireHandlerTest.java
+++ b/Server/src/test/java/octoteam/tahiti/server/pipeline/SessionExpireHandlerTest.java
@@ -1,0 +1,47 @@
+package octoteam.tahiti.server.pipeline;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import octoteam.tahiti.protocol.SocketMessageProtos.SessionExpiredEventBody;
+import octoteam.tahiti.protocol.SocketMessageProtos.Message;
+import octoteam.tahiti.server.event.RateLimitExceededEvent;
+import octoteam.tahiti.server.ratelimiter.CounterBasedRateLimiter;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SessionExpireHandlerTest {
+
+    /**
+     * clear session once count of messages from client exceeded
+     */
+
+    @Test
+    public void testSessionExpired() {
+        EmbeddedChannel channel = new EmbeddedChannel(new RequestRateLimitHandler(
+                Message.ServiceCode.PING_REQUEST,
+                RateLimitExceededEvent.NAME_PER_SESSION,
+                () -> new CounterBasedRateLimiter(2)), new SessionExpireHandler());
+
+        for (int i = 0; i < 3; i++) {
+            Message pingRequest = Message.newBuilder()
+                    .setSeqId(1)
+                    .setDirection(Message.DirectionCode.REQUEST)
+                    .setService(Message.ServiceCode.PING_REQUEST)
+                    .build();
+            channel.writeInbound(pingRequest);
+            if (i == 2) {
+                // only care about EVENT message
+                Object response = channel.readOutbound();
+                assertTrue(response instanceof Message);
+
+                Message responseMsg = (Message) response;
+                assertEquals(responseMsg.getDirection(), Message.DirectionCode.EVENT);
+                assertEquals(responseMsg.getService(), Message.ServiceCode.SESSION_EXPIRED_EVENT);
+                assertEquals(responseMsg.getSessionExpiredEvent().getReason(),
+                        SessionExpiredEventBody.Reason.EXPIRED);
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
may still need test to see whether other channels receive the constructed CHAT_BROADCAST_MESSAGE messages, but cannot find solution to make `clients` in MessageForwardHandler to add second instance of EmbeddedChannel.
